### PR TITLE
Add Makefile and dev env targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# global python binary
+PYTHON_BIN = $(shell which python3)
+
+# virtual env directories and binaries
+VENV_DIR        = venv
+VENV_PYTHON_BIN = $(VENV_DIR)/bin/python
+PIP_BIN         = $(VENV_DIR)/bin/pip
+BLACK_BIN       = $(VENV_DIR)/bin/black
+TWINE_BIN       = $(VENV_DIR)/bin/twine
+
+.PHONY: lint test build docs deploy
+
+# setup dev environment, eg. `make venv`
+$(VENV_DIR): requirements.txt requirements.dev.txt
+	test -d $(VENV_DIR) || $(PYTHON_BIN) -m venv $(VENV_DIR) && $(PIP_BIN) install -U pip setuptools wheel
+	$(PIP_BIN) install -r requirements.txt
+	$(PIP_BIN) install -r requirements.dev.txt
+	touch $(VENV_DIR)
+
+lint:
+	$(BLACK_BIN) .
+
+test: ally/tests.py
+	$(VENV_PYTHON_BIN) ally/tests.py
+
+build:
+	$(VENV_PYTHON_BIN) setup.py sdist bdist_wheel
+
+docs:
+	cd sphinx && \
+	make github
+
+deploy:
+	$(TWINE_BIN) upload dist/*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,29 @@ articles has had trouble suppling some information.
 * Multi-leg orders
 
 
+## Dev Environment Setup
 
+To setup your dev environment, simply run:
+
+```bash
+make venv # run once
+source venv/bin/activate # run for every new terminal
+```
+
+This will install the library requirements for debugging as well as some useful tools to lint, test, build, document, and deploy. See the `Makefile` for a list of useful targets.
+
+### Dev Environment Teardown
+
+To exit the dev environment, simply run:
+
+```bash
+deactivate
+```
+or `exit` / `logout` your terminal.
+
+### Fixing Your Dev Environment
+
+If your dev environment gets hosed, exit it, remove the `venv` directory, and run the setup above again.
 
 ## Contributors
 * [Brett Graves](https://github.com/alienbrett)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 black
 isort
+mypy
 pylint
 twine
 sphinx

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,6 @@
+black
+isort
+pylint
+twine
+sphinx
+sphinx-rtd-theme>=0.5.1,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytz>=2020.5,<2021.0
+requests>=2.25.1,<3.0.0
+requests-oauthlib>=1.3.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pandas>=1.2.1,<2.0.0
 pytz>=2020.5,<2021.0
 requests>=2.25.1,<3.0.0
 requests-oauthlib>=1.3.0,<2.0.0


### PR DESCRIPTION
This adds a simple `Makefile` which will setup all needed tools on a developers machine to be able to contribute to this repo. They simply just run the commands below (included in new sections in the README.md):
```bash
make venv # run once
source venv/bin/activate # run for every new terminal
```

@mm0 I am moving my PRs here as the source repo seems to be stale. Original: https://github.com/alienbrett/PyAlly/pull/59