### PR TITLE
Add back looser version requirements for pandas

### DIFF
--- a/ally/Api.py
+++ b/ally/Api.py
@@ -190,7 +190,7 @@ class StreamEndpoint(AuthenticatedEndpoint):
                 except StopIteration:
                     pass
                 else:
-                    if 'quote' in row or 'trade' in row:
+                    if "quote" in row or "trade" in row:
                         yield row
                 finally:
                     del it

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=1.1.5,<2.0.0
+pandas>=0.23.1,<2.0.0
 pytz>=2020.5,<2021.0
 requests>=2.25.1,<3.0.0
 requests-oauthlib>=1.3.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
+pandas>=1.1.5,<2.0.0
 pytz>=2020.5,<2021.0
 requests>=2.25.1,<3.0.0
 requests-oauthlib>=1.3.0,<2.0.0


### PR DESCRIPTION
Not all developers had `pandas==1.2.1` available to their systems. This adds back the requirement but loosens the min version requirement.

See https://github.com/mm0/PyAlly/pull/1#issuecomment-791885017 and https://github.com/mm0/PyAlly/pull/1/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R1 for original issue.

See https://github.com/pandas-dev/pandas/compare/v0.23.4...v1.2.1 for version differences.